### PR TITLE
correct non existing command 'ip dev'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -224,7 +224,7 @@ CHANGES WITH 248:
           systemd.network files gained a new ActivationPolicy= setting which
           allows configuring how the UP state of an interface shall be managed,
           i.e. whether the interface is always upped, always downed, or may be
-          upped/downed by the user using "ip dev".
+          upped/downed by the user using "ip link set dev".
 
         * The default for the Broadcast= setting in .network files has slightly
           changed: the broadcast address will not be configured for wireguard


### PR DESCRIPTION
'ip dev' does not exist. 'ip link set dev' is the correct command.